### PR TITLE
Feature/test builds

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -1,0 +1,102 @@
+name: Build (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      bump_version:
+        required: false
+        default: false
+        type: boolean
+      version:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  build:
+    name: Build ox_lib
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.6.1
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16.x
+          cache: 'pnpm'
+          cache-dependency-path: 'web/pnpm-lock.yaml'
+
+      - name: Set env
+        if: inputs.version != ''
+        run: echo "RELEASE_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: pnpm install
+        working-directory: web
+
+      - name: Install package dependencies
+        run: pnpm install
+        working-directory: package
+
+      - name: Bump package version
+        if: inputs.bump_version
+        run: pnpm version ${{ inputs.version }}
+        working-directory: package
+
+      - name: Run build
+        run: pnpm build
+        working-directory: web
+        env:
+          CI: false
+
+      - name: Bump manifest version
+        if: inputs.bump_version
+        run: node .github/actions/bump-manifest-version.js
+        env:
+          TGT_RELEASE_VERSION: ${{ inputs.version }}
+
+      - name: Push manifest change
+        if: inputs.bump_version
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: fxmanifest.lua
+          push: true
+          author_name: Manifest Bumper
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
+          message: 'chore: bump manifest version to ${{ inputs.version }}'
+
+      - name: Bundle files
+        run: |
+          mkdir -p ./temp/ox_lib
+          mkdir -p ./temp/ox_lib/web/
+          cp ./{LICENSE,README.md,fxmanifest.lua,init.lua} ./temp/ox_lib
+          cp -r ./{imports,resource,locales} ./temp/ox_lib
+          cp -r ./web/build ./temp/ox_lib/web/
+          
+      - name: Upload plugin build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ox_lib_plugin_build
+          path: ./temp/
+      
+      - name: Build and publish package
+        uses: JS-DevTools/npm-publish@v3
+        if: inputs.bump_version
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: './package/package.json'
+          access: 'public'
+
+      - name: Build package
+        if: !inputs.bump_version
+        working-directory: package
+        run: pnpm run compile
+
+

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -95,7 +95,7 @@ jobs:
           access: 'public'
 
       - name: Build package
-        if: !inputs.bump_version
+        if: inputs.bump_version == false
         working-directory: package
         run: pnpm run compile
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+    name: Build ox_lib
+    uses: ./.github/workflows/build-reusable.yml
+    with:
+      bump_version: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,95 +6,40 @@ on:
       - 'v*.*.*'
 
 jobs:
+  build:
+    name: Build Release
+    uses: ./.github/workflows/build-reusable.yml
+    with:
+      bump_version: true
+      version: ${{ github.ref_name }}
+
   create-release:
-    name: Build and Create Tagged Release
+    name: Create Release
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Install archive tools
-        run: sudo apt install zip
-
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.repository.default_branch }}
-
-      - uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 8.6.1
-
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          cache: 'pnpm'
-          cache-dependency-path: 'web/pnpm-lock.yaml'
-
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: pnpm install
-        working-directory: web
-
-      - name: Install package dependencies
-        run: pnpm install
-        working-directory: package
-
-      - name: Bump package version
-        run: pnpm version ${{ github.ref_name }}
-        working-directory: package
-
-      - name: Run build
-        run: pnpm build
-        working-directory: web
-        env:
-          CI: false
-
-      - name: Bump manifest version
-        run: node .github/actions/bump-manifest-version.js
-        env:
-          TGT_RELEASE_VERSION: ${{ github.ref_name }}
-
-      - name: Push manifest change
-        uses: EndBug/add-and-commit@v8
-        with:
-          add: fxmanifest.lua
-          push: true
-          author_name: Manifest Bumper
-          author_email: 41898282+github-actions[bot]@users.noreply.github.com
-          message: 'chore: bump manifest version to ${{ github.ref_name }}'
+          name: ox_lib_plugin_build
 
       - name: Update tag ref
         uses: EndBug/latest-tag@latest
         with:
-          tag-name: ${{ github.ref_name }}
+          ref: ${{ github.ref_name }}
 
-      - name: Bundle files
-        run: |
-          mkdir -p ./temp/ox_lib
-          mkdir -p ./temp/ox_lib/web/
-          cp ./{LICENSE,README.md,fxmanifest.lua,init.lua} ./temp/ox_lib
-          cp -r ./{imports,resource,locales} ./temp/ox_lib
-          cp -r ./web/build ./temp/ox_lib/web/
-          cd ./temp && zip -r ../ox_lib.zip ./ox_lib
-
+      # This dependency is archived, possibly replace it with a maintained one
       - name: Create Release
-        uses: 'marvinpinto/action-automatic-releases@v1.2.1'
+        uses: marvinpinto/action-automatic-releases@v1.2.1
         id: auto_release
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          title: ${{ env.RELEASE_VERSION }}
+          title: ${{ github.ref_name }}
           prerelease: false
           files: ox_lib.zip
-
         env:
           CI: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish npm package
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: './package/package.json'
-          access: 'public'


### PR DESCRIPTION
Changes GitHub Action pipelines to allow for test builds of PRs and updated dependencies to use the latest major release.

The logic of bundling and building files is unchanged, but moved to a separate reusable workflow and file zipping is now covered by the "upload artifact" step.

Possible future improvements:

    Replacing dependency for generating releases with a maintained project
    Moving publish logic to the release.yml file. I've kept it in the reusable workflow atm since moving it to the release.yml would mean having to reinstall pnpm packages and negate some of the simplifications

